### PR TITLE
When installs non-globally from npm registry, list is nil initially when no package was installed locally

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -33,7 +33,7 @@ module NodeJs
     def npm_package_installed?(package, version = nil, path = nil)
       list = npm_list(path)['dependencies']
       # Return true if package installed and installed to good version
-      list.key?(package) && (version ? list[package]['version'] == version : true)
+      (!list.nil?) && list.key?(package) && (version ? list[package]['version'] == version : true)
     end
   end
 end


### PR DESCRIPTION
npm installation would fails with:
## NoMethodError

undefined method `key?' for nil:NilClass
## Cookbook Trace:

/var/chef/cache/cookbooks/nodejs/libraries/nodejs_helper.rb:36:in `npm_package_installed?'
/var/chef/cache/cookbooks/nodejs/providers/npm.rb:28:in`installed?'
/var/chef/cache/cookbooks/nodejs/providers/npm.rb:12:in `block (3 levels) in class_from_file'
