### PR TITLE
Increase max nesting on npm install check JSON parse

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -27,7 +27,7 @@ module NodeJs
       else
         cmd = Mixlib::ShellOut.new('npm list -global -json')
       end
-      JSON.parse(cmd.run_command.stdout)
+      JSON.parse(cmd.run_command.stdout, :max_nesting => 100)
     end
 
     def npm_package_installed?(package, version = nil, path = nil)


### PR DESCRIPTION
I was running into errors when using the npm_package LWRP:

```
JSON::NestingError: execute[install NPM package gulp] (/tmp/vagrant-chef-3/chef-solo-1/cookbooks/nodejs/providers/npm.rb line 6) had an error: JSON::NestingError: nesting of 20 is too deep
```

Increasing the max_nesting to 100 resolved this.
