### PR TITLE
Add a node install packages recipe

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,0 +1,16 @@
+#
+# Author:: Paul Bonaud (paul@bonaud.fr)
+# Cookbook Name:: nodejs
+# Recipe:: packages
+#
+# This recipe gives you the ability to install node packages
+# via chef configuration
+#
+
+if node['nodejs'].has_key?('node_packages')
+  node['nodejs']['node_packages'].each do |node_pkg|
+    nodejs_npm node_pkg['name'] do
+      version node_pkg['version'] if node_pkg.has_key?('version')
+    end if node_pkg.has_key?('name')
+  end
+end


### PR DESCRIPTION
**Hello!**

Thanks for this cookbook it was very useful for my needs.

I simply lacked a simple recipe to install node packages quickly via chef configuration. The recipe is pretty basic for now (it only installs node packages globally, and can only specify `version` and `name`)

_Example of usage in a solo run:_

``` json
{
  "nodejs": {
    "node_packages": [
      { "name": "bower" },
      { "name": "grunt", "version": "0.4.5" }
    ]
  },
  "run_list": [
    [...],
    "recipe[nodejs::packages]"
    [...],
  ]
}
```

**_This was useful for quick provisioning purposes, let me know what you think**_
