### PR TITLE
Avoid conflict with chef-sugar

### DIFF
--- a/providers/npm.rb
+++ b/providers/npm.rb
@@ -9,7 +9,7 @@ action :install do
     user new_resource.user
     group new_resource.group
     environment 'HOME' => ::Dir.home(new_resource.user), 'USER' => new_resource.user if new_resource.user
-    not_if { installed? }
+    not_if { is_installed? }
   end
 end
 
@@ -20,11 +20,11 @@ action :uninstall do
     user new_resource.user
     group new_resource.group
     environment 'HOME' => ::Dir.home(new_resource.user), 'USER' => new_resource.user if new_resource.user
-    only_if { installed? }
+    only_if { is_installed? }
   end
 end
 
-def installed?
+def is_installed?
   new_resource.package && npm_package_installed?(new_resource.package, new_resource.version, new_resource.path)
 end
 


### PR DESCRIPTION
sethvargo/chef-sugar imports an `installed?` into `Chef::Provider` at
runtime. This means as-it-stands a recipe importing chef-sugar recieves
an "ArgumentError: wrong number of arguments (0 for 1)" if it tries to
use the nodejs_npm resource.

This is unfortunate because it prevents me from using the npm resource
in a recipe that may run on hosts that don't already have npm installed.

If the cookbooks are compatible, I can use sugar's `compile_time`
(or `before`) context to make sure the node-installing recipes run
before `npm_list` gets called in the guard.

Without sugar, compile-time installation of node is much harder. Manual
use of `run_action` is possible, but complicated by the various paths
the nodejs recipes can take.

A name change here renders them compatible for this use.
