### PR TITLE
fixes max_nesting for npm source installs

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -7,7 +7,7 @@ module NodeJs
 
         require 'open-uri'
         require 'json'
-        result = JSON.parse(URI.parse("https://registry.npmjs.org/npm/#{node['nodejs']['npm']['version']}", :max_nesting => false).read)
+        result = JSON.parse(URI.parse("https://registry.npmjs.org/npm/#{node['nodejs']['npm']['version']}").read, :max_nesting => false)
         ret = { 'url' => result['dist']['tarball'], 'version' => result['_npmVersion'], 'shasum' => result['dist']['shasum'] }
         Chef::Log.debug("Npm dist #{ret}")
         return ret


### PR DESCRIPTION
Fixes a syntax error in 3cc49c20 that results in the following converge error when `node['nodejs']['npm']['install_method'] == 'source'` :

```
ArgumentError
-------------
wrong number of arguments (2 for 1)
```
