### PR TITLE
Is not possible to modify json file

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,8 +25,8 @@ node['nodejs']['npm_packages'].each do |pkg|
   f = nodejs_npm pkg['name'] do
     action :nothing
   end
-  pkg.reject { |k, _v| k == 'name' || k == 'action' }.each do |key, value|
-    f.send(key, value)
+  pkg.each do |key, value|
+    f.send(key, value) unless key == 'name' || key == 'action'
   end
   action = pkg.key?('action') ? pkg['action'] : :install
   f.action(action)


### PR DESCRIPTION
Hi, this fixes bug, when you have additional keys.

It's not possible to modify original son file

```
==> production: 
==> production: ================================================================================
==> production: Recipe Compile Error in /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb
==> production: ================================================================================
==> production: 
==> production: 
==> production: Chef::Exceptions::ImmutableAttributeModification
==> production: ------------------------------------------------
==> production: Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'
==> production: 
==> production: 
==> production: Cookbook Trace:
==> production: ---------------
==> production:   /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb:28:in `initialize_dup'
==> production:   /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb:28:in `reject'
==> production:   /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb:28:in `block in from_file'
==> production:   /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb:24:in `each'
==> production:   /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb:24:in `from_file'
==> production: 
==> production: Relevant File Content:
==> production: ----------------------
==> production: /tmp/vagrant-chef-2/chef-solo-1/cookbooks/nodejs/recipes/default.rb:
==> production: 
==> production:  21:  include_recipe 'nodejs::nodejs'
==> production:  22:  include_recipe 'nodejs::npm'
==> production:  23:  
==> production:  24:  node['nodejs']['npm_packages'].each do |pkg|
==> production:  25:    f = nodejs_npm pkg['name'] do
==> production:  26:      action :nothing
==> production:  27:    end
==> production:  28>>   pkg.reject { |k, _v| k == 'name' || k == 'action' }.each do |key, value|
==> production:  29:      f.send(key, value)
==> production:  30:    end
==> production:  31:    action = pkg.key?('action') ? pkg['action'] : :install
==> production:  32:    f.action(action)
==> production:  33:  end if node['nodejs'].key?('npm_packages')
==> production:  34:  
==> production: 
==> production: [2014-09-29T09:09:40+00:00] ERROR: Running exception handlers
==> production: [2014-09-29T09:09:40+00:00] ERROR: Exception handlers complete
==> production: [2014-09-29T09:09:40+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> production: [2014-09-29T09:09:40+00:00] ERROR: Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'
==> production: [2014-09-29T09:09:40+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```
