### PR TITLE
Added install_path attribute to customize installation directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+# Chef stuff
 Gemfile.lock
 Berksfile.lock
-tmp/
 .kitchen
 .kitchen.local.yml
+
+# Temp files
+tmp/
+
+# Editors
+.idea

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver_plugin: vagrant
 driver_config:
   require_chef_omnibus: true
   customize:
-    memory: 512
+    memory: 2048
     cpus: 4
 
 platforms:
@@ -51,6 +51,25 @@ suites:
       source:
         checksum: 55e79cc4f4cde41f03c1e204d2af5ee4b6e4edcf14defc82e518436e939195fa
       version: 2.2.1
+- name: binary-install-path
+  run_list:
+  - recipe[nodejs]
+  - recipe[nodejs_test::npm_with_nodejs_home]
+  attributes:
+    nodejs:
+      install_method: binary
+      nodejs_home: /tmp/node-binary
+      install_path: /tmp
+- name: source-install-path
+  run_list:
+  - recipe[nodejs]
+  - recipe[nodejs_test::npm_with_nodejs_home]
+  attributes:
+    nodejs:
+      install_directory_name: node-source
+      install_method: source
+      nodejs_home: /tmp/node-source
+      install_path: /tmp
 - name: npm
   run_list:
   - recipe[nodejs::npm]
@@ -81,4 +100,3 @@ suites:
           version: 1.0.4
         - name: express
           action: uninstall
-

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ node.default['nodejs']['version'] = '5.9.0'
 node.default['nodejs']['binary']['checksum'] = '99c4136cf61761fac5ac57f80544140a3793b63e00a65d4a0e528c9db328bf40' 
 ```
 
+To customize the installation directory path, change the value of the `install_path` attribute (by default it is: `nil`):
+```chef
+node['nodejs']['install_path'] = '/opt'
+```
+As a result you get a directory `/opt/node-binary/bin` with the binaries.
+_Warning:_ If the above attribute is not `nil` then the symlinks are not created.
+
+To customize the installation directory name change the value of the `install_directory_name` attribute:
+```chef
+node['nodejs']['install_path'] = '/opt'
+node['nodejs']['install_directory_name'] = 'my_nodejs'
+```
+As a result you get a directory `/opt/my_nodejs/bin` with the binaries.
+
 #### Source
 
 Install node from sources:
@@ -61,6 +75,19 @@ include_recipe "nodejs"
 # Or
 include_recipe "nodejs::nodejs_from_source"
 ```
+
+To customize the installation directory path, change the value of the `install_path` attribute (by default it is: `nil`):
+```chef
+node['nodejs']['install_path'] = '/opt'
+```
+As a result you get a directory `/opt/node-binary/bin` with the binaries.
+
+To customize the installation directory name change the value of the `install_directory_name` attribute:
+```chef
+node['nodejs']['install_path'] = '/opt'
+node['nodejs']['install_directory_name'] = 'my_nodejs'
+```
+As a result you get a directory `/opt/my_nodejs/bin` with the binaries.
 
 ## NPM
 
@@ -94,6 +121,14 @@ You can append more specific options to npm command with `attribute :options` ar
  * use an array of options (w/ dash), they will be added to npm call.
  * ex: `['--production','--force']` or `['--force-latest']`
  
+If you have installed nodejs in custom directory, you should pass additional `nodejs_home` attribute to `nodejs_npm` resource.
+```chef
+nodejs_npm 'appium' do
+ nodejs_home '/opt/nodejs-binary'
+end
+```
+Or if you used `install_path` attribute to customize the installation directory then the `nodejs_home` is not necessary.
+
 This LWRP attempts to use vanilla npm as much as possible (no custom wrapper).
 
 ### Packages

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,9 @@ end
 
 default['nodejs']['engine'] = 'node' # or iojs
 
+default['nodejs']['install_path'] = nil
+default['nodejs']['install_directory_name'] = "#{default['nodejs']['engine']}-binary"
+
 default['nodejs']['version'] = '0.10.26'
 
 default['nodejs']['prefix_url']['node'] = 'https://nodejs.org/dist/'

--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -14,13 +14,17 @@ module NodeJs
       end
     end
 
-    def npm_list(path = nil, environment = {})
+    def npm_list(path = nil, environment = {}, nodejs_home = nil)
       require 'json'
       if path
         cmd = Mixlib::ShellOut.new('npm list -json', :cwd => path, :environment => environment)
       else
         cmd = Mixlib::ShellOut.new('npm list -global -json', :environment => environment)
       end
+
+      nodejs_home = custom_nodejs_home(nodejs_home)
+
+      cmd.environment['PATH'] = "#{nodejs_home}/bin:" + ENV['PATH'] if nodejs_home
 
       JSON.parse(cmd.run_command.stdout, :max_nesting => false)
     end
@@ -33,12 +37,46 @@ module NodeJs
       (version ? list[package]['version'] == version : true)
     end
 
-    def npm_package_installed?(package, version = nil, path = nil, npm_token = nil)
+    def npm_package_installed?(new_resource)
+      package = new_resource.package
+      version = new_resource.version
+      path = new_resource.path
+      nodejs_home = new_resource.nodejs_home
+      npm_token = new_resource.npm_token
+
       environment = { 'NPM_TOKEN' => npm_token } if npm_token
 
-      list = npm_list(path, environment)['dependencies']
+      list = npm_list(path, environment, nodejs_home)['dependencies']
       # Return true if package installed and installed to good version
       (!list.nil?) && list.key?(package) && version_valid?(list, package, version) && url_valid?(list, package)
+    end
+
+    def npm_env_vars(new_resource)
+      environment = {}
+      if new_resource.user
+        environment['HOME'] = ::Dir.home(new_resource.user)
+        environment['USER'] = new_resource.user
+      end
+
+      environment['NPM_TOKEN'] = new_resource.npm_token if new_resource.npm_token
+
+      nodejs_home = custom_nodejs_home(new_resource.nodejs_home)
+
+      environment['PATH'] = "#{nodejs_home}/bin:" + ENV['PATH'] if nodejs_home
+
+      environment
+    end
+
+    def custom_nodejs_home(nodejs_home)
+      if nodejs_home.nil? && !node['nodejs']['install_path'].nil?
+        nodejs_home = "#{node['nodejs']['install_path']}/#{node['nodejs']['install_directory_name']}"
+      end
+
+      custom_nodejs_home = !nodejs_home.nil? && !ENV['PATH'].include?(nodejs_home)
+
+      return nodejs_home if custom_nodejs_home
+
+      nil
     end
   end
 end

--- a/providers/npm.rb
+++ b/providers/npm.rb
@@ -8,7 +8,7 @@ action :install do
     command "npm install #{npm_options}"
     user new_resource.user
     group new_resource.group
-    environment npm_env_vars
+    environment npm_env_vars(new_resource)
     not_if { package_installed? }
   end
 end
@@ -19,22 +19,13 @@ action :uninstall do
     command "npm uninstall #{npm_options}"
     user new_resource.user
     group new_resource.group
-    environment npm_env_vars
+    environment npm_env_vars(new_resource)
     only_if { package_installed? }
   end
 end
 
-def npm_env_vars
-  env_vars = {}
-  env_vars['HOME'] = ::Dir.home(new_resource.user) if new_resource.user
-  env_vars['USER'] = new_resource.user if new_resource.user
-  env_vars['NPM_TOKEN'] = new_resource.npm_token if new_resource.npm_token
-
-  env_vars
-end
-
 def package_installed?
-  new_resource.package && npm_package_installed?(new_resource.package, new_resource.version, new_resource.path, new_resource.npm_token)
+  new_resource.package && npm_package_installed?(new_resource)
 end
 
 def npm_options

--- a/recipes/nodejs_from_binary.rb
+++ b/recipes/nodejs_from_binary.rb
@@ -34,11 +34,9 @@ prefix = node['nodejs']['prefix_url'][node['nodejs']['engine']]
 
 if node['nodejs']['engine'] == 'iojs'
   filename = "iojs-v#{node['nodejs']['version']}-linux-#{arch}.tar.gz"
-  archive_name = 'iojs-binary'
   binaries = ['bin/iojs', 'bin/node']
 else
   filename = "node-v#{node['nodejs']['version']}-linux-#{arch}.tar.gz"
-  archive_name = 'nodejs-binary'
   binaries = ['bin/node']
 end
 
@@ -52,10 +50,13 @@ else
   checksum = node['nodejs']['binary']['checksum']["linux_#{arch}"]
 end
 
-ark archive_name do
+output = node['nodejs']['install_directory_name']
+
+ark output do
   url nodejs_bin_url
   version node['nodejs']['version']
+  path node['nodejs']['install_path']
   checksum checksum
   has_binaries binaries
-  action :install
+  action node['nodejs']['install_path'].nil? ? :install : :put
 end

--- a/recipes/nodejs_from_source.rb
+++ b/recipes/nodejs_from_source.rb
@@ -36,17 +36,22 @@ prefix = node['nodejs']['prefix_url'][node['nodejs']['engine']]
 
 if node['nodejs']['engine'] == 'iojs'
   filename = "iojs-v#{node['nodejs']['version']}.tar.gz"
-  archive_name = 'iojs-source'
 else
   filename = "node-v#{node['nodejs']['version']}.tar.gz"
-  archive_name = 'nodejs-source'
 end
 
 nodejs_src_url = node['nodejs']['source']['url'] || ::URI.join(prefix, version, filename).to_s
 
-ark archive_name do
+output = node['nodejs']['install_directory_name']
+
+ark output do
   url nodejs_src_url
   version node['nodejs']['version']
+  unless node['nodejs']['install_path'].nil?
+    prefix_root node['nodejs']['install_path']
+    prefix_home node['nodejs']['install_path']
+    autoconf_opts ["--prefix=#{node['nodejs']['install_path']}/#{output}"]
+  end
   checksum node['nodejs']['source']['checksum']
   make_opts ["-j #{node['nodejs']['make_threads']}"]
   action :install_with_make

--- a/resources/npm.rb
+++ b/resources/npm.rb
@@ -25,6 +25,7 @@ default_action :install
 attribute :package, :name_attribute => true
 attribute :version, :kind_of => String
 attribute :path, :kind_of => String
+attribute :nodejs_home, :kind_of => String, :default => nil
 attribute :url, :kind_of => String
 attribute :json, :kind_of => [String, TrueClass]
 attribute :npm_token, :kind_of => String

--- a/test/cookbooks/nodejs_test/recipes/npm_with_nodejs_home.rb
+++ b/test/cookbooks/nodejs_test/recipes/npm_with_nodejs_home.rb
@@ -1,0 +1,8 @@
+# Tests nodejs_home attribute
+
+include_recipe 'git'
+
+nodejs_npm 'appium' do
+  nodejs_home "/tmp/node-#{node['nodejs']['install_method']}"
+  options ['--unsafe-perm']
+end

--- a/test/integration/binary-install-path/bats/binary-install-path.bats
+++ b/test/integration/binary-install-path/bats/binary-install-path.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "appium should be in the path" {
+  [ "$(command -v /tmp/node-binary/bin/appium)" ]
+}

--- a/test/integration/source-install-path/bats/source-install-path.bats
+++ b/test/integration/source-install-path/bats/source-install-path.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "appium should be in the path" {
+  [ "$(command -v /tmp/node-source/bin/appium)" ]
+}


### PR DESCRIPTION
Currently node js for binary/source version is installed to default location `/usr/local/` and symlinked to `/usr/local/bin`. I made some changes to control the install location and if user decides to install node  that way, then the symlinks are not created by default. 
Ex. For some reason user might want to install three different versions of nodejs for testing purposes.
