### PR TITLE
allow passing options to package resource

### DIFF
--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -12,3 +12,6 @@ when 'node'
 when 'iojs'
   default['nodejs']['packages'] = ['iojs']
 end
+
+default['nodejs']['package_options'] = nil
+default['nodejs']['package_action'] = 'install'

--- a/recipes/nodejs_from_package.rb
+++ b/recipes/nodejs_from_package.rb
@@ -31,5 +31,8 @@ unless node['nodejs']['packages']
 end
 
 node['nodejs']['packages'].each do |node_pkg|
-  package node_pkg
+  package node_pkg do
+    options node['nodejs']['package_options']
+    action node['nodejs']['package_action']
+  end
 end


### PR DESCRIPTION
Hi,

Without this, we have to rely on forking or rewinding to overwrite the package.

This PR doesnt change the default behavior and allow passing options to dpkg for example in a wrapper cookbook.

It also allows to always upgrade for example by overriding the action.

Before this PR:

``` ruby

chef_gem 'chef-rewind' do
  compile_time true
end

require 'chef/rewind'

include_recipe 'nodejs'

node['nodejs']['packages'].each do |pkg|
  rewind %|package[#{pkg}]| do
    options "--force-yes -o Dpkg::Options::='--force-confold'"
  end
end
```

Cheers!
