### PR TITLE
Adds Windows support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 case node['platform_family']
-when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x'
+when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x', 'windows'
   default['nodejs']['install_method'] = 'package'
 else
   default['nodejs']['install_method'] = 'source'
@@ -27,6 +27,7 @@ end
 default['nodejs']['engine'] = 'node' # or iojs
 
 default['nodejs']['version'] = '6.9.1'
+default['nodejs']['use_latest_package'] = true
 
 default['nodejs']['prefix_url']['node'] = 'https://nodejs.org/dist/'
 default['nodejs']['prefix_url']['iojs'] = 'https://iojs.org/dist/'

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -7,7 +7,7 @@ when 'node'
     default['nodejs']['repo']      = 'https://deb.nodesource.com/node'
     default['nodejs']['keyserver'] = 'keyserver.ubuntu.com'
     default['nodejs']['key']       = '1655a0ab68576280'
-  when 'rhel'
+  when 'rhel', 'windows'
     default['nodejs']['install_repo'] = true
   end
 when 'iojs'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,8 @@ depends 'build-essential'
 depends 'ark'
 depends 'apt', '>= 2.9.1'
 depends 'homebrew'
+depends 'chocolatey'
 
-%w(debian ubuntu centos redhat scientific oracle amazon smartos mac_os_x).each do |os|
+%w(debian ubuntu centos redhat scientific oracle amazon smartos mac_os_x windows).each do |os|
   supports os
 end

--- a/recipes/nodejs_from_package.rb
+++ b/recipes/nodejs_from_package.rb
@@ -31,5 +31,16 @@ unless node['nodejs']['packages']
 end
 
 node['nodejs']['packages'].each do |node_pkg|
-  package node_pkg
+  case node['platform_family']
+  when 'windows'
+    # This separate case for windows is needed because Chocolatey
+    # doesn't provide the built-in 'package' resource of Chef.
+    chocolatey node_pkg do
+      version node[node_pkg]['version'] unless node['nodejs']['use_latest_package']
+    end
+  else
+    package node_pkg do
+      version node[node_pkg]['version'] unless node['nodejs']['use_latest_package']
+    end
+  end
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -11,4 +11,6 @@ when 'debian'
   end
 when 'rhel'
   include_recipe 'yum-epel'
+when 'windows'
+  include_recipe 'chocolatey'
 end


### PR DESCRIPTION
Utilizes the Chocolatey package manager for installing nodejs.
#102 does not work for installing all versions of nodejs because it downloads installers from URLs, but URLs to x64 installers have changed between versions:

Example:
https://nodejs.org/dist/v0.12.9/x64/node-v0.12.9-x64.msi
vs.
https://nodejs.org/dist/v4.4.2/node-v4.4.2-x64.msi
