### PR TITLE
[npm-registry-url]

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,7 +16,7 @@ platforms:
 - name: ubuntu-10.04
   run_list:
   - recipe[apt]
-- name: centos-6.5
+- name: centos-6.7
 - name: centos-5.10
 
 suites:

--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -22,11 +22,18 @@ module NodeJs
         cmd = Mixlib::ShellOut.new('npm list -global -json', :environment => environment)
       end
 
-      JSON.parse(cmd.run_command.stdout, :max_nesting => false)
+      begin
+        JSON.parse(cmd.run_command.stdout, :max_nesting => false)
+      rescue JSON::ParserError => e
+        Chef::Log.error("nodejs::library::nodejs_helper::npm_list exception #{e}")
+        return false
+      end
     end
 
     def url_valid?(list, package)
-      list.fetch(package, {}).fetch('resolved', '').include?('url')
+      require 'open-uri'
+
+      URI.parse(list.fetch(package, {}).fetch('resolved'))
     end
 
     def version_valid?(list, package, version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures node.js & io.js'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/redguide/nodejs' if respond_to?(:source_url)
 issues_url 'https://github.com/redguide/nodejs/issues' if respond_to?(:issues_url)
-version '2.4.5'
+version '2.4.6'
 
 conflicts 'node'
 
@@ -19,5 +19,3 @@ depends 'homebrew'
 %w(debian ubuntu centos redhat smartos mac_os_x).each do |os|
   supports os
 end
-
-suggests 'application_nodejs'


### PR DESCRIPTION
- fixed npm package install occuring everytime due to list json data structure change. there no longer is a url attribute. resolved now is set to url.
- rescue if JSON.parse throws an exception when npm list 
- validated the url really is valid using open-uri
- bumped test-kitchen centos 6 suite to 6.7 since 6.5 appears to be gone
- removed unimplemented "suggests" key word due to FC052
- bumped cookbook version 2.4.6
