### PR TITLE
Support installing from package/binary for Windows. Make binary install less linux-specific.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Installs node.js/io.js and manages npm
 
 - Debian/Ubuntu
 - RHEL/CentOS/Scientific/Amazon/Oracle
+- Mac OSX
+- Windows
 
 Note: Source installs require GCC 4.8+, which is not included on older distro releases
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 case node['platform_family']
-when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x'
+when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x', 'windows'
   default['nodejs']['install_method'] = 'package'
 else
   default['nodejs']['install_method'] = 'source'
@@ -31,12 +31,23 @@ default['nodejs']['version'] = '6.9.1'
 default['nodejs']['prefix_url']['node'] = 'https://nodejs.org/dist/'
 default['nodejs']['prefix_url']['iojs'] = 'https://iojs.org/dist/'
 
+default['nodejs']['package']['url'] = nil # Auto generated
+# Checksums are necessary for Windows. Here's the default checksums for 6.9.1
+default['nodejs']['package']['checksum']['win_x64'] = '148aa14ce1491b2cdc47230c90e862e48d1af32baf5cc415b29593b6113ea1cf'
+default['nodejs']['package']['checksum']['win_x86'] = '314eaf8b5b9e08a835cb5c005ea5f4299b9e9e4d8c97277c1617e511382c15dc'
+
 default['nodejs']['source']['url']      = nil # Auto generated
 default['nodejs']['source']['checksum'] = '0bdd8d1305777cc8cd206129ea494d6c6ce56001868dd80147aff531d6df0729'
 
 default['nodejs']['binary']['url'] = nil # Auto generated
+default['nodejs']['binary']['win_install_dir'] = nil # Auto generated
 default['nodejs']['binary']['checksum']['linux_x64'] = 'd4eb161e4715e11bbef816a6c577974271e2bddae9cf008744627676ff00036a'
 default['nodejs']['binary']['checksum']['linux_x86'] = 'f9b2ca03016e45bc35d2441a63a73db94d3e7b92350f15577d796467b9f7efb0'
 default['nodejs']['binary']['checksum']['linux_arm64'] = '7aa69b6c8cff578d0d97d5bd4f76941b2fade5476f0408d53828666ee427dd4e'
+default['nodejs']['binary']['checksum']['win_x64'] = '6ea6768af81948bd0e54760d948f04e0ab182411b235d2067e45a1e2b9052bcb'
+default['nodejs']['binary']['checksum']['win_x86'] = 'aec417a95b46a21fa13190ed3f9a22de8bc1ecec77f981102345b0c7165420bd'
+default['nodejs']['binary']['checksum']['darwin_x64'] = '910395e1e98fb351c62b5702a9deef22aaecf05d6df1d7edc283337542207f3f'
+default['nodejs']['binary']['checksum']['sunos_x64'] = 'd94202bc4567475ccca077f3f819a92c9d7f280bac688ec0506f9a31c3b19201'
+default['nodejs']['binary']['checksum']['sunos_x86'] = '643d675ac6678745784b29ab829519d11c9832aa77095a9b611d71b7ac4d4321'
 
 default['nodejs']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 2

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,6 @@ depends 'ark'
 depends 'apt', '>= 2.9.1'
 depends 'homebrew'
 
-%w(debian ubuntu centos redhat scientific oracle amazon smartos mac_os_x).each do |os|
+%w(debian ubuntu centos redhat scientific oracle amazon smartos mac_os_x windows).each do |os|
   supports os
 end

--- a/recipes/nodejs_from_binary.rb
+++ b/recipes/nodejs_from_binary.rb
@@ -20,6 +20,7 @@ Chef::Recipe.send(:include, NodeJs::Helper)
 
 node.force_override['nodejs']['install_method'] = 'binary' # ~FC019
 
+# FIXME: Handle s390x, ppc64, arm64, armv61, armv71, ppc64le
 # Shamelessly borrowed from http://docs.chef.io/dsl_recipe_method_platform.html
 # Surely there's a more canonical way to get arch?
 arch = if node['kernel']['machine'] =~ /armv6l/
@@ -32,12 +33,32 @@ arch = if node['kernel']['machine'] =~ /armv6l/
 version = "v#{node['nodejs']['version']}/"
 prefix = node['nodejs']['prefix_url'][node['nodejs']['engine']]
 
+# Choose short platform name and file extension based on our platform family
+# Used to buidl the URL
+case node['platform_family']
+when 'windows'
+  platform = 'win'
+  extension = '7z'
+when 'mac_os_x'
+  platform = 'darwin'
+  extension = 'tar.xz'
+when 'aix'
+  platform = 'aix'
+  extension = 'tar.gz'
+when 'smartos', 'omnios', 'openindiana', 'opensolaris', 'solaris2', 'nexentacore'
+  platform = 'sunos'
+  extension = 'tar.xz'
+else
+  platform = 'linux'
+  extension = 'tar.xz'
+end
+
 if node['nodejs']['engine'] == 'iojs'
-  filename = "iojs-v#{node['nodejs']['version']}-linux-#{arch}.tar.xz"
+  filename = "iojs-v#{node['nodejs']['version']}-#{platform}-#{arch}.#{extension}"
   archive_name = 'iojs-binary'
   binaries = ['bin/iojs', 'bin/node']
 else
-  filename = "node-v#{node['nodejs']['version']}-linux-#{arch}.tar.xz"
+  filename = "node-v#{node['nodejs']['version']}-#{platform}-#{arch}.#{extension}"
   archive_name = 'nodejs-binary'
   binaries = ['bin/node']
 end
@@ -49,7 +70,14 @@ if node['nodejs']['binary']['url']
   checksum = node['nodejs']['binary']['checksum']
 else
   nodejs_bin_url = ::URI.join(prefix, version, filename).to_s
-  checksum = node['nodejs']['binary']['checksum']["linux_#{arch}"]
+  checksum = node['nodejs']['binary']['checksum']["#{platform}_#{arch}"]
+end
+
+if node['nodejs']['binary']['win_install_dir']
+  win_install_dir = node['nodejs']['binary']['win_install_dir']
+else
+  # FIXME: Use Program Files(x86) if installing 32-bit version on 64-bit windows!
+  win_install_dir = "C:\\Program Files\\#{archive_name}"
 end
 
 ark archive_name do
@@ -57,5 +85,7 @@ ark archive_name do
   version node['nodejs']['version']
   checksum checksum
   has_binaries binaries
+  append_env_path true
+  win_install_dir win_install_dir
   action :install
 end


### PR DESCRIPTION
- Add support for installing nodejs from package or binary for windows.
- Make installing from binary more platform-agnostic to support windows/mac and not just assume linux. (Use tar.xz for most platforms, us 7z for Windows)
- Add default checksums for windows and mac (and not just linux)

Signed-off-by: Christopher Williams <chris.a.williams@gmail.com>