### PR TITLE
Add ability to set NODE_ENV for npm_package

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Packages can be installed globally (by default) or in a directory (by using `att
 
 You can specify an `NPM_TOKEN` environment variable for accessing [NPM private modules](https://docs.npmjs.com/private-modules/intro) by using `attribute :npm_token`
 
+You can specify a `NODE_ENV` environment variable, in the case that some element of your installation depends on this by using `attribute :node_env`. E.g., using [`node-config`](https://www.npmjs.com/package/config) as part of your postinstall script. Please note that adding the `--production` option will override this to `NODE_ENV=production`.
+
 You can append more specific options to npm command with `attribute :options` array :
 
 - use an array of options (w/ dash), they will be added to npm call.
@@ -139,6 +141,7 @@ npm_package 'grunt' do
   path '/home/random/grunt'
   json true
   user 'random'
+  node_env 'staging'
 end
 
 npm_package 'my_private_module' do

--- a/resources/npm_package.rb
+++ b/resources/npm_package.rb
@@ -33,6 +33,7 @@ property :npm_token, String
 property :options, Array, default: []
 property :user, String
 property :group, String
+property :node_env, String
 
 def initialize(*args)
   super
@@ -69,6 +70,7 @@ action_class do
     env_vars['HOME'] = ::Dir.home(new_resource.user) if new_resource.user
     env_vars['USER'] = new_resource.user if new_resource.user
     env_vars['NPM_TOKEN'] = new_resource.npm_token if new_resource.npm_token
+    env_vars['NODE_ENV'] =  new_resource.node_env if new_resource.node_env
 
     env_vars
   end

--- a/test/cookbooks/test/recipes/resource.rb
+++ b/test/cookbooks/test/recipes/resource.rb
@@ -50,6 +50,7 @@ end
 npm_package 'from_package_json' do
   path '/home/random'
   json true
+  user 'random'
   npm_token '123-abcde'
-  options ['--production']
+  node_env 'staging' # Test node_env usage
 end

--- a/test/cookbooks/test/templates/package.json
+++ b/test/cookbooks/test/templates/package.json
@@ -10,9 +10,13 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
+    "config": "^1.26.2",
     "koa": "^1.1.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0"
+  },
+  "scripts": {
+    "postinstall": "touch $NODE_ENV"
   }
 }

--- a/test/integration/binary/default.rb
+++ b/test/integration/binary/default.rb
@@ -6,4 +6,8 @@ control 'commands should exist' do
   describe command('npm -v') do
     its('exit_status') { should eq 0 }
   end
+
+  describe file '/home/random/staging' do
+    it { should exist }
+  end
 end

--- a/test/integration/package/default.rb
+++ b/test/integration/package/default.rb
@@ -6,4 +6,8 @@ control 'commands should exist' do
   describe command('npm -v') do
     its('exit_status') { should eq 0 }
   end
+
+  describe file '/home/random/staging' do
+    it { should exist }
+  end
 end

--- a/test/integration/source/default.rb
+++ b/test/integration/source/default.rb
@@ -6,4 +6,8 @@ control 'commands should exist' do
   describe command('npm -v') do
     its('exit_status') { should eq 0 }
   end
+
+  describe file '/home/random/staging' do
+    it { should exist }
+  end
 end


### PR DESCRIPTION
### Description

* Adds the ability to provide `NODE_ENV` to the `npm install` process
    - Important to note that setting `--production` overrides `NODE_ENV`

### Issues Resolved

* n/a

### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable