### PR TITLE
Add chocolatey install method

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,7 @@ platforms:
   - name: opensuse-leap-42
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: windows
 
 suites:
 - name: package
@@ -33,6 +34,11 @@ suites:
   - recipe[test::source]
   excludes:
     - centos-6
+- name: chocolatey
+  run_list:
+  - recipe[test::chocolatey]
+  includes:
+    - windows
 - name: npm
   run_list:
   - recipe[test::npm]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Installs node.js/npm and includes a resource for managing npm packages
 - Debian/Ubuntu
 - RHEL/CentOS/Scientific/Amazon/Oracle
 - openSUSE
+- Windows
 
 Note: Source installs require GCC 4.8+, which is not included on older distro releases
 
@@ -77,6 +78,17 @@ node['nodejs']['install_method'] = 'source'
 include_recipe "nodejs"
 # Or
 include_recipe "nodejs::nodejs_from_source"
+```
+
+#### Chocolatey
+
+Install node from chocolatey:
+
+```chef
+node['nodejs']['install_method'] = 'chocolatey'
+include_recipe "nodejs"
+# Or
+include_recipe "nodejs::nodejs_from_chocolatey"
 ```
 
 ## NPM

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,8 @@
 case node['platform_family']
 when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x', 'suse', 'amazon'
   default['nodejs']['install_method'] = 'package'
+when 'windows'
+  default['nodejs']['install_method'] = 'chocolatey'
 else
   default['nodejs']['install_method'] = 'source'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,11 +8,11 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/redguide/nodejs'
 issues_url 'https://github.com/redguide/nodejs/issues'
 chef_version '>= 12.14' if respond_to?(:chef_version)
-version '6.0.0'
+version '6.1.0'
 
 depends 'build-essential', '>= 5.0'
 depends 'ark', '>= 2.0.2'
 
-%w(debian ubuntu centos redhat scientific oracle amazon smartos mac_os_x opensuseleap suse).each do |os|
+%w(debian ubuntu centos redhat scientific oracle amazon smartos mac_os_x opensuseleap suse windows).each do |os|
   supports os
 end

--- a/recipes/nodejs_from_chocolatey.rb
+++ b/recipes/nodejs_from_chocolatey.rb
@@ -18,11 +18,11 @@
 
 chocolatey_package 'nodejs-lts' do
   version node['nodejs']['version']
-  action :install
+  action :upgrade
   only_if node['nodejs']['version']
 end
 
 chocolatey_package 'nodejs-lts' do
-  action :install
+  action :upgrade
   not_if node['nodejs']['version']
 end

--- a/recipes/nodejs_from_chocolatey.rb
+++ b/recipes/nodejs_from_chocolatey.rb
@@ -1,0 +1,28 @@
+#
+# Author:: Hossein Margani (hossein@margani.dev)
+# Cookbook:: nodejs
+# Recipe:: install_from_chocolatey
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chocolatey_package 'nodejs-lts' do
+  version node['nodejs']['version']
+  action :install
+  only_if node['nodejs']['version']
+end
+
+chocolatey_package 'nodejs-lts' do
+  action :install
+  not_if node['nodejs']['version']
+end

--- a/test/cookbooks/test/recipes/chocolatey.rb
+++ b/test/cookbooks/test/recipes/chocolatey.rb
@@ -1,0 +1,5 @@
+apt_update 'update'
+
+node.default['nodejs']['install_method'] = 'chocolatey'
+include_recipe 'nodejs::default'
+include_recipe 'test::resource'


### PR DESCRIPTION
### Description

Adds a new install method which installs the LTS version of NodeJS using [Chocolatey](https://chocolatey.org/packages/nodejs-lts).

It sets the default install method to it for windows platform.

### Issues Resolved

With this install method, we can install NodeJS for windows too.

### Check List

- [ ] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
