### PR TITLE
Add npx as binary for binary & source installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - resolved cookstyle error: recipes/npm_from_source.rb:21:1 refactor: `ChefCorrectness/IncorrectLibraryInjection`
 - Have ark setup node and npm binaries into PATH
 - Add `node_env` to `npm_package` in order to set `NODE_ENV` (useful for some packages)
+- Include `npx` as a binary in addition to `npm`, it has been [included since `npm` v5.2.0](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)
 
 ## 7.0.1 (2020-06-04)
 

--- a/recipes/nodejs_from_binary.rb
+++ b/recipes/nodejs_from_binary.rb
@@ -47,6 +47,7 @@ archive_name = 'nodejs-binary'
 binaries = ['bin/node']
 
 binaries.push('bin/npm') if node['nodejs']['npm']['install_method'] == 'embedded'
+binaries.push('bin/npx') if node['nodejs']['npm']['install_method'] == 'embedded'
 
 if node['nodejs']['binary']['url']
   nodejs_bin_url = node['nodejs']['binary']['url']

--- a/test/integration/binary/default.rb
+++ b/test/integration/binary/default.rb
@@ -10,4 +10,8 @@ control 'commands should exist' do
   describe file '/home/random/staging' do
     it { should exist }
   end
+
+  describe command('npx -v') do
+    its('exit_status') { should eq 0 }
+  end
 end

--- a/test/integration/source/default.rb
+++ b/test/integration/source/default.rb
@@ -10,4 +10,8 @@ control 'commands should exist' do
   describe file '/home/random/staging' do
     it { should exist }
   end
+
+  describe command('npx -v') do
+    its('exit_status') { should eq 0 }
+  end
 end


### PR DESCRIPTION
### Description

As of npm v5.2.0, this tool has been available & is quite handy. See https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b for details.

### Issues Resolved

None

### Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable