### PR TITLE
Add the auto_update option to the npm_package resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NodeJS Cookbook Changelog
 
+## unreleased
+
+- Add the auto_update option to the npm_package resource. Allows turning off auto_update of npm packages.
+
 ## 7.2.0 (2020-10-07)
 
 - Verify the URI of installed packages to help determine if a good URI has been installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NodeJS Cookbook Changelog
 
-## unreleased
+## Unreleased
 
 - Add the auto_update option to the npm_package resource. Allows turning off auto_update of npm packages.
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ You can specify a `NODE_ENV` environment variable, in the case that some element
 
 You can append more specific options to npm command with `attribute :options` array :
 
+You can specify auto_update as false to stop the npm install command from running and updating an installed package. Running the command will update packages within restrictions imposed by a package.json file. The default behavior is to update automatically.
+
 - use an array of options (w/ dash), they will be added to npm call.
 - ex: `['--production','--force']` or `['--force-latest']`
 

--- a/resources/npm_package.rb
+++ b/resources/npm_package.rb
@@ -36,6 +36,7 @@ property :user, String
 property :group, String
 property :live_stream, [false, true], default: false
 property :node_env, String
+property :auto_update, [true, false], default: true
 
 def initialize(*args)
   super
@@ -50,7 +51,7 @@ action :install do
     group new_resource.group
     environment npm_env_vars
     live_stream new_resource.live_stream
-    not_if { package_installed? }
+    not_if { package_installed? && no_auto_update? }
   end
 end
 
@@ -81,6 +82,10 @@ action_class do
 
   def package_installed?
     new_resource.package && npm_package_installed?(new_resource.package, new_resource.version, new_resource.path, new_resource.npm_token)
+  end
+
+  def no_auto_update?
+    new_resource.package && !new_resource.auto_update
   end
 
   def npm_options

--- a/test/cookbooks/test/recipes/resource.rb
+++ b/test/cookbooks/test/recipes/resource.rb
@@ -25,6 +25,23 @@ npm_package 'async' do
   version '0.6.2'
 end
 
+npm_package 'xss' do
+  version '1.0.7'
+end
+
+npm_package 'xss noupgrade' do
+  package 'xss'
+  auto_update false
+end
+
+npm_package 'minify' do
+  version '5.2.0'
+end
+
+npm_package 'minify upgrade' do
+  package 'minify'
+end
+
 npm_package 'request' do
   url 'github mikeal/request'
 end

--- a/test/integration/package/default.rb
+++ b/test/integration/package/default.rb
@@ -18,6 +18,14 @@ control 'commands should exist' do
     its('stdout') { should match(/mocha/) }
   end
 
+  describe command('npm list xss -json -global') do
+    its('stdout') { should match(/"version":\s*"1.0.7"/) }
+  end
+
+  describe command('npm list minify -json -global') do
+    its('stdout') { should_not match(/"version":\s*"5.2.0"/) }
+  end
+
   describe command('export NPM_TOKEN="123-abcde" && cd /home/random && npm list -json') do
     its('stdout') { should match(/koa/) }
     its('stdout') { should match(/gulp/) }


### PR DESCRIPTION
Allows stopping the default behavior of doing an update if possible.

### Description

[Describe what this change achieves]

### Issues Resolved

Replaces PR #159

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
